### PR TITLE
Add new prop for delaying siblings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# React Animate On Scroll
+# Articulate - React Animate On Scroll
+**NOTE: This is a fork of the original [react-animate-on-scroll](https://github.com/dbramwell/react-animate-on-scroll) by dbramwell and has been modified to meet articulate's needs.**
+
+
 React component to animate elements on scroll with [animate.css](https://daneden.github.io/animate.css/).
 Inspired by [React-Scroll-Effect](https://github.com/anorudes/react-scroll-effects)
 
@@ -7,7 +10,7 @@ Inspired by [React-Scroll-Effect](https://github.com/anorudes/react-scroll-effec
 ## Install:
 
 ```
-npm install react-animate-on-scroll --save
+npm install articulate-react-animate-on-scroll --save
 ```
 **If you want to use the animations from animate.css, be sure to include animate.css in someway in your project**
 This can be done in a number of ways, eg:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Travis](https://travis-ci.org/dbramwell/react-animate-on-scroll.svg?branch=master)](https://travis-ci.org/dbramwell/react-animate-on-scroll)
-
 # React Animate On Scroll
 React component to animate elements on scroll with [animate.css](https://daneden.github.io/animate.css/).
 Inspired by [React-Scroll-Effect](https://github.com/anorudes/react-scroll-effects)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-animate-on-scroll",
-  "version": "2.1.4",
+  "name": "articulate-react-animate-on-scroll",
+  "version": "2.2.0",
   "description": "React component to animate elements on scroll with animate.css",
   "main": "dist/scrollAnimation.min.js",
   "scripts": {
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dbramwell/react-animate-on-scroll"
+    "url": "https://github.com/articulate/react-animate-on-scroll"
   },
   "keywords": [
     "reactScrollEffects",
@@ -20,12 +20,11 @@
     "animation",
     "reactAnimateOnScroll"
   ],
-  "author": "dbramwell",
+  "author": "articulate",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/dbramwell/react-animate-on-scroll/issues"
+    "url": "https://github.com/articulate/react-animate-on-scroll/issues"
   },
-  "homepage": "http://dbramwell.github.io/react-animate-on-scroll",
   "peerDependencies": {
     "classnames": "^2.2.5",
     "react": ">= 15.4.1 < 17.0.0-0"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "articulate-react-animate-on-scroll",
+  "name": "@articulate/react-animate-on-scroll",
   "version": "2.2.0",
   "description": "React component to animate elements on scroll with animate.css",
   "main": "dist/scrollAnimation.min.js",

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -193,13 +193,38 @@ export default class ScrollAnimation extends Component {
     }
   }
 
-  render() {
-    var classes = this.props.className ? `${this.props.className} ${this.state.classes}` : this.state.classes;
+  renderChild(child, classes, style, key = 0) {
     return (
-      <div ref={(node) => { this.node = node; }} className={classes} style={Object.assign({}, this.state.style, this.props.style)}>
-        {this.props.children}
+      <div className={classes} style={style} key={key}>
+        {child}
       </div>
     );
+  }
+
+  renderChildren(classes, style) {
+    const { children, duration, siblingDelay } = this.props;
+
+    if (siblingDelay && Array.isArray(children)) {
+      return [...Array(children.length).keys()].map((siblingIndex) => {
+        const siblingStyle = Object.assign({}, style, { animationDuration: (duration + siblingDelay * siblingIndex) + 's'})
+
+        return this.renderChild(children[siblingIndex], classes, siblingStyle, siblingIndex)
+      })
+    } else {
+      return this.renderChild(children, classes, style);
+    }
+
+  }
+
+  render() {
+    const classes = this.props.className ? `${this.props.className} ${this.state.classes}` : this.state.classes;
+    const style = Object.assign({}, this.state.style, this.props.style);
+
+    return (
+      <div ref={(node) => { this.node = node; }}>
+        {this.renderChildren(classes, style)}
+      </div>
+    )
   }
 }
 
@@ -208,7 +233,8 @@ ScrollAnimation.defaultProps = {
   duration: 1,
   initiallyVisible: false,
   delay: 0,
-  animateOnce: false
+  animateOnce: false,
+  siblingDelay: 0
 };
 
 ScrollAnimation.propTypes = {
@@ -221,5 +247,6 @@ ScrollAnimation.propTypes = {
   animateOnce: PropTypes.bool,
   style: PropTypes.object,
   scrollableParentSelector: PropTypes.string,
-  className: PropTypes.string
+  className: PropTypes.string,
+  siblingDelay: PropTypes.number
 };


### PR DESCRIPTION
This is being added because we want to animate a group of child elements individually (with increasing animation-delay on each successive child) on scroll by adding animations to each child. The problem we had with the original implementation was that if we wanted to animate each child individually, they would also be triggered individually on scroll. We wanted all child animations to be triggered when the first child was scrolled into view.

A new prop has been added called `siblingDelay` that takes a number representing the time in seconds to be used to delay each sibling. The animation duration is lengthened using the sibling delay. I wanted to use `animation-delay` but unfortunately that didn't work as the elements became visible before the animation began.

This implementation breaks the tests, they will need to be completely reworked now that the dom structure is slightly different, for the sake of time I am leaving them broken and will create an issue for the animation tests. This has been tested with animated blocks on rise-frontend.