### PR TITLE
Correctly implement sibling animation delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/react-animate-on-scroll",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "React component to animate elements on scroll with animate.css",
   "main": "dist/scrollAnimation.min.js",
   "scripts": {

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -290,7 +290,7 @@ class AnimatedElement extends Component {
   render() {
     const { children, classes } = this.props
     const { hasAnimated } = this.state
-    const { styles: propStyles } = this.props
+    const propStyles = this.props.style
     const opacity = propStyles.animationDelay !== undefined ? 0 : propStyles.opacity
     const style = Object.assign({}, propStyles, { opacity: hasAnimated ? 1 : opacity })
 

--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -290,9 +290,9 @@ class AnimatedElement extends Component {
   render() {
     const { children, classes } = this.props
     const { hasAnimated } = this.state
-    const propStyles = this.props.style
+    const { styles: propStyles } = this.props
     const opacity = propStyles.animationDelay !== undefined ? 0 : propStyles.opacity
-    const style = Object.assign({}, this.props.style, { opacity: hasAnimated ? 1 : opacity })
+    const style = Object.assign({}, propStyles, { opacity: hasAnimated ? 1 : opacity })
 
     return (
       <div className={classes} style={style} ref={ref => this.ref = ref}>


### PR DESCRIPTION
I previously resorted to using animation duration to simulate an animation delay in order to avoid the issues I faced with opacity timing. It ended up being no bueno, as the sequential animations did not look quite right. 

To correctly implement the sequential sibling animations I had to create another component to wrap the siblings. The new component is responsible to controlling the opacity change timing. (Such a pain!)