### PR TITLE
Restore support for initially visible property.

### DIFF
--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -232,13 +232,14 @@ export default class ScrollAnimation extends Component {
   }
 
   renderChild(child, classes, index = 0) {
-    const { siblingDelay } = this.props
+    const { initiallyVisible, siblingDelay } = this.props
     const  delay = siblingDelay * index
     const style = Object.assign({}, this.state.style, this.props.style, { animationDelay: `${delay}s` })
 
     return (
       <AnimatedElement
         classes={classes}
+        initiallyVisible={initiallyVisible}
         style={style}
         key={index}
       >
@@ -326,10 +327,10 @@ class AnimatedElement extends Component {
   }
 
   render() {
-    const { children, classes } = this.props
+    const { initiallyVisible, children, classes } = this.props
     const { hasAnimated } = this.state
     const propStyles = this.props.style
-    const opacity = propStyles.animationDelay !== undefined ? 0 : propStyles.opacity
+    const opacity = (propStyles.animationDelay !== undefined && !initiallyVisible) ? 0 : propStyles.opacity
     const style = Object.assign({}, propStyles, { opacity: hasAnimated ? 1 : opacity })
 
     return (


### PR DESCRIPTION
This little PR adds support for the documented `initiallyVisible` property.  This property is documented but I think we busted support for it with some of our own modifications.

I need to use `initiallyVisible` to get the UX we want for labeled graphic blocks.