### PR TITLE
Fix crashes when navigating between lessons on learn page

### DIFF
--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -109,12 +109,18 @@ export default class ScrollAnimation extends Component {
   }
 
   componentWillUnmount() {
+    this.cleanup()
+  }
+
+  cleanup() {
     clearTimeout(this.delayedAnimationTimeout);
     clearTimeout(this.callbackTimeout);
+
     if (window && window.removeEventListener) {
-      window.removeEventListener("scroll", this.listener);
+      window.removeEventListener("scroll", this.listener)
     }
   }
+
 
   visibilityHasChanged(previousVis, currentVis) {
     return previousVis.inViewport !== currentVis.inViewport ||
@@ -210,6 +216,15 @@ export default class ScrollAnimation extends Component {
 
   handleScroll() {
     if (!this.animating) {
+
+        // Hack: There seems to be an issue with the way we are doing routing on the learn page, animations, and react component
+        // lifecycle events.  For whatever reason, if you navigate quickly from lesson to lesson on the lesson overview page,
+        // zombie event listeners are left hanging out observing scroll events.  This hack removes the zombie listeners when detected
+        if (!this.node) {
+          this.cleanup()
+          return true
+        }
+
       const currentVis = this.getVisibility();
       if (this.visibilityHasChanged(this.visibility, currentVis)) {
         clearTimeout(this.delayedAnimationTimeout);
@@ -307,15 +322,18 @@ class AnimatedElement extends Component {
 
   componentDidMount() {
     this.animationEndListener = this.ref.addEventListener('animationend', () => {
-
-      this.setState({
-        hasAnimated: true
-      })
+      if (this.ref) {
+        this.setState({
+          hasAnimated: true
+        })
+      }
     })
   }
 
   componentWillUnmount() {
-    this.ref.removeEventListener('animationend', this.animationEndListener)
+    if (this.ref) {
+      this.ref.removeEventListener('animationend', this.animationEndListener)
+    }
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
After digging into this issue with @JWA111 , we have come to the conclusion that something about how we are routing on the learn page isn't playing nicely with React component lifecycle hooks.  Somehow our entrance animation components appear to be mounted but never unmounted in some edge cases when rapidly switching between lessons.

This change set is a quick fix to remove our barrier to shipping.  I will file a separate chore to investigate fixing this issue, as block entrance animations are not the only place this problem is occurring - we also have a similar problem with our `TrackViewed` component.

[I have filed an engineering chore here for this task.](https://github.com/articulate/rise-runtime/issues/2277)

![fflbpuo](https://user-images.githubusercontent.com/3892771/41560043-8cc92ca6-730b-11e8-8859-06203bb0a331.jpg)


