### PR TITLE
Chore: Clean up code styling

### DIFF
--- a/src/scroll-animation.js
+++ b/src/scroll-animation.js
@@ -1,110 +1,122 @@
-import React, { Component } from "react";
-import throttle from "lodash.throttle";
-import PropTypes from "prop-types";
+import React, { Component } from 'react'
+import throttle from 'lodash.throttle'
+import PropTypes from 'prop-types'
 
 export default class ScrollAnimation extends Component {
-
   constructor(props) {
-    super(props);
-    this.serverSide = typeof window === "undefined";
-    this.listener = throttle(this.handleScroll.bind(this), 50);
+    super(props)
+
+    this.serverSide = typeof window === 'undefined'
+    this.listener = throttle(this.handleScroll.bind(this), 50)
+
     this.visibility = {
+      inViewport: false,
       onScreen: false,
-      inViewport: false
-    };
+    }
 
     this.state = {
-      classes: "animated",
+      classes: 'animated',
       style: {
         animationDuration: `${this.props.duration}s`,
-        opacity: this.props.initiallyVisible ? 1 : 0
-      }
-    };
+        opacity: this.props.initiallyVisible ? 1 : 0,
+      },
+    }
   }
 
   getElementTop(elm) {
-    var yPos = 0;
+    var yPos = 0
+
     while (elm && elm.offsetTop !== undefined && elm.clientTop !== undefined) {
-      yPos += (elm.offsetTop + elm.clientTop);
-      elm = elm.offsetParent;
+      yPos += elm.offsetTop + elm.clientTop
+      elm = elm.offsetParent
     }
-    return yPos;
+
+    return yPos
   }
 
   getScrollPos() {
     if (this.scrollableParent.pageYOffset !== undefined) {
-      return this.scrollableParent.pageYOffset;
+      return this.scrollableParent.pageYOffset
     }
-    return this.scrollableParent.scrollTop;
+
+    return this.scrollableParent.scrollTop
   }
 
   getScrollableParentHeight() {
     if (this.scrollableParent.innerHeight !== undefined) {
-      return this.scrollableParent.innerHeight;
+      return this.scrollableParent.innerHeight
     }
-    return this.scrollableParent.clientHeight;
+
+    return this.scrollableParent.clientHeight
   }
 
   getViewportTop() {
-    return this.getScrollPos() + this.props.offset;
+    return this.getScrollPos() + this.props.offset
   }
 
   getViewportBottom() {
-    return this.getScrollPos() + this.getScrollableParentHeight() - this.props.offset;
+    return this.getScrollPos() + this.getScrollableParentHeight() - this.props.offset
   }
 
   isInViewport(y) {
-    return y >= this.getViewportTop() && y <= this.getViewportBottom();
+    return y >= this.getViewportTop()
+      && y <= this.getViewportBottom()
   }
 
   isAboveViewport(y) {
-    return y < this.getViewportTop();
+    return y < this.getViewportTop()
   }
 
   isBelowViewport(y) {
-    return y > this.getViewportBottom();
+    return y > this.getViewportBottom()
   }
 
   inViewport(elementTop, elementBottom) {
-    return this.isInViewport(elementTop) || this.isInViewport(elementBottom) ||
-      (this.isAboveViewport(elementTop) && this.isBelowViewport(elementBottom));
+    return this.isInViewport(elementTop)
+      || this.isInViewport(elementBottom)
+      || this.isAboveViewport(elementTop) && this.isBelowViewport(elementBottom)
   }
 
   onScreen(elementTop, elementBottom) {
-    return !this.isAboveScreen(elementBottom) && !this.isBelowScreen(elementTop);
+    return !this.isAboveScreen(elementBottom)
+      && !this.isBelowScreen(elementTop)
   }
 
   isAboveScreen(y) {
-    return y < this.getScrollPos();
+    return y < this.getScrollPos()
   }
 
   isBelowScreen(y) {
-    return y > this.getScrollPos() + this.getScrollableParentHeight();
+    return y > this.getScrollPos() + this.getScrollableParentHeight()
   }
 
   getVisibility() {
-    const elementTop = this.getElementTop(this.node) - this.getElementTop(this.scrollableParent);
-    const elementBottom = elementTop + this.node.clientHeight;
+    const elementTop = this.getElementTop(this.node) - this.getElementTop(this.scrollableParent)
+    const elementBottom = elementTop + this.node.clientHeight
     const inViewport = this.inViewport(elementTop, elementBottom)
 
     return {
-      inViewport: inViewport,
       aboveViewport: this.isAboveViewport(elementTop),
       belowViewport: this.isBelowViewport(elementTop),
-      onScreen: this.onScreen(elementTop, elementBottom)
-    };
+      inViewport: inViewport,
+      onScreen: this.onScreen(elementTop, elementBottom),
+    }
   }
 
   componentDidMount() {
-    if(!this.serverSide) {
+    if (!this.serverSide) {
       const parentSelector = this.props.scrollableParentSelector
-      this.scrollableParent = parentSelector ? document.querySelector(parentSelector) : window;
+
+      this.scrollableParent = parentSelector
+        ? document.querySelector(parentSelector)
+        : window
+
       if (this.scrollableParent && this.scrollableParent.addEventListener) {
-        this.scrollableParent.addEventListener("scroll", this.listener);
+        this.scrollableParent.addEventListener('scroll', this.listener)
       } else {
-        console.warn(`Cannot find element by locator: ${this.props.scrollableParentSelector}`);
+        console.warn(`Cannot find element by locator: ${this.props.scrollableParentSelector}`)
       }
-      this.handleScroll();
+      this.handleScroll()
     }
   }
 
@@ -113,31 +125,32 @@ export default class ScrollAnimation extends Component {
   }
 
   cleanup() {
-    clearTimeout(this.delayedAnimationTimeout);
-    clearTimeout(this.callbackTimeout);
+    clearTimeout(this.delayedAnimationTimeout)
+    clearTimeout(this.callbackTimeout)
 
     if (window && window.removeEventListener) {
-      window.removeEventListener("scroll", this.listener)
+      window.removeEventListener('scroll', this.listener)
     }
   }
 
-
   visibilityHasChanged(previousVis, currentVis) {
-    return previousVis.inViewport !== currentVis.inViewport ||
-      previousVis.onScreen !== currentVis.onScreen;
+    return previousVis.inViewport !== currentVis.inViewport
+      || previousVis.onScreen !== currentVis.onScreen
   }
 
   animate(animation, callback) {
     this.delayedAnimationTimeout = setTimeout(() => {
-      this.animating = true;
+      this.animating = true
+
       this.setState({
         classes: `animated ${animation}`,
         style: {
-          animationDuration: `${this.props.duration}s`
-        }
-      });
-      this.callbackTimeout = setTimeout(callback, this.props.duration * 1000);
-    }, this.props.delay);
+          animationDuration: `${this.props.duration}s`,
+        },
+      })
+
+      this.callbackTimeout = setTimeout(callback, this.props.duration * 1000)
+    }, this.props.delay)
   }
 
   animateIn(callback) {
@@ -146,38 +159,41 @@ export default class ScrollAnimation extends Component {
         this.setState({
           style: {
             animationDuration: `${this.props.duration}s`,
-            opacity: 1
-          }
-        });
-        this.animating = false;
+            opacity: 1,
+          },
+        })
+        this.animating = false
       }
-      const vis = this.getVisibility();
+
+      const vis = this.getVisibility()
       if (callback) {
-        callback(vis);
+        callback(vis)
       }
-    });
+    })
   }
 
   animateOut(callback) {
     this.animate(this.props.animateOut, () => {
       this.setState({
-        classes: "animated",
+        classes: 'animated',
         style: {
           animationDuration: `${this.props.duration}s`,
-          opacity: 0
-        }
-      });
-      const vis = this.getVisibility();
+          opacity: 0,
+        },
+      })
+
+      const vis = this.getVisibility()
+
       if (vis.inViewport && this.props.animateIn) {
-        this.animateIn(this.props.afterAnimatedIn);
+        this.animateIn(this.props.afterAnimatedIn)
       } else {
-        this.animating = false;
+        this.animating = false
       }
 
       if (callback) {
-        callback(vis);
+        callback(vis)
       }
-    });
+    })
   }
 
   shouldNotAnimate(currentVis) {
@@ -216,32 +232,34 @@ export default class ScrollAnimation extends Component {
 
   handleScroll() {
     if (!this.animating) {
+      // Hack: There seems to be an issue with the way we are doing routing on the learn page, animations, and react component
+      // lifecycle events.  For whatever reason, if you navigate quickly from lesson to lesson on the lesson overview page,
+      // zombie event listeners are left hanging out observing scroll events.  This hack removes the zombie listeners when detected
+      if (!this.node) {
+        this.cleanup()
+        return true
+      }
 
-        // Hack: There seems to be an issue with the way we are doing routing on the learn page, animations, and react component
-        // lifecycle events.  For whatever reason, if you navigate quickly from lesson to lesson on the lesson overview page,
-        // zombie event listeners are left hanging out observing scroll events.  This hack removes the zombie listeners when detected
-        if (!this.node) {
-          this.cleanup()
-          return true
-        }
+      const currentVis = this.getVisibility()
 
-      const currentVis = this.getVisibility();
       if (this.visibilityHasChanged(this.visibility, currentVis)) {
-        clearTimeout(this.delayedAnimationTimeout);
+        clearTimeout(this.delayedAnimationTimeout)
+
         if (this.shouldNotAnimate(currentVis)) {
           this.setState({
-            classes: "animated",
+            classes: 'animated',
             style: {
               animationDuration: `${this.props.duration}s`,
-              opacity: this.props.initiallyVisible ? 1 : 0
-            }
-          });
+              opacity: this.props.initiallyVisible ? 1 : 0,
+            },
+          })
         } else if (this.shouldAnimateIn(currentVis)) {
-          this.animateIn(this.props.afterAnimatedIn);
+          this.animateIn(this.props.afterAnimatedIn)
         } else if (this.shouldAnimateOut(currentVis)) {
-          this.animateOut(this.props.afterAnimatedOut);
+          this.animateOut(this.props.afterAnimatedOut)
         }
-        this.visibility = currentVis;
+
+        this.visibility = currentVis
       }
     }
   }
@@ -249,14 +267,19 @@ export default class ScrollAnimation extends Component {
   renderChild(child, classes, index = 0) {
     const { initiallyVisible, siblingDelay } = this.props
     const  delay = siblingDelay * index
-    const style = Object.assign({}, this.state.style, this.props.style, { animationDelay: `${delay}s` })
+
+    const style = Object.assign(
+      {},
+      this.state.style,
+      this.props.style, { animationDelay: `${delay}s` }
+    )
 
     return (
       <AnimatedElement
         classes={classes}
         initiallyVisible={initiallyVisible}
-        style={style}
         key={index}
+        style={style}
       >
         {child}
       </AnimatedElement>
@@ -267,17 +290,18 @@ export default class ScrollAnimation extends Component {
     const { children, siblingDelay } = this.props
 
     if (siblingDelay && Array.isArray(children)) {
-      return [ ...Array(children.length).keys() ].map((siblingIndex) => {
-        return this.renderChild(children[siblingIndex], classes, siblingIndex)
-      })
+      return [ ...Array(children.length).keys() ].map(
+        siblingIndex =>  this.renderChild(children[siblingIndex], classes, siblingIndex)
+      )
     } else {
       return this.renderChild(children, classes)
     }
-
   }
 
   render() {
-    const classes = this.props.className ? `${this.props.className} ${this.state.classes}` : this.state.classes
+    const classes = this.props.className
+      ? `${this.props.className} ${this.state.classes}`
+      : this.state.classes
 
     return (
       <div ref={(node) => { this.node = node }}>
@@ -288,44 +312,41 @@ export default class ScrollAnimation extends Component {
 }
 
 ScrollAnimation.defaultProps = {
-  offset: 150,
+  animateOnce: false,
+  delay: 0,
   duration: 1,
   initiallyVisible: false,
-  delay: 0,
-  animateOnce: false,
-  siblingDelay: 0
+  offset: 150,
+  siblingDelay: 0,
 }
 
 ScrollAnimation.propTypes = {
   animateIn: PropTypes.string,
-  animateOut: PropTypes.string,
-  offset: PropTypes.number,
-  duration: PropTypes.number,
-  delay: PropTypes.number,
-  initiallyVisible: PropTypes.bool,
   animateOnce: PropTypes.bool,
-  style: PropTypes.object,
-  scrollableParentSelector: PropTypes.string,
+  animateOut: PropTypes.string,
   className: PropTypes.string,
-  siblingDelay: PropTypes.number
+  delay: PropTypes.number,
+  duration: PropTypes.number,
+  initiallyVisible: PropTypes.bool,
+  offset: PropTypes.number,
+  scrollableParentSelector: PropTypes.string,
+  siblingDelay: PropTypes.number,
+  style: PropTypes.object,
 }
 
 class AnimatedElement extends Component {
-
   constructor(props) {
     super(props)
 
     this.state = {
-      hasAnimated: false
+      hasAnimated: false,
     }
   }
 
   componentDidMount() {
     this.animationEndListener = this.ref.addEventListener('animationend', () => {
       if (this.ref) {
-        this.setState({
-          hasAnimated: true
-        })
+        this.setState({ hasAnimated: true })
       }
     })
   }
@@ -338,18 +359,29 @@ class AnimatedElement extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.style.opacity === 0) {
-      this.setState({
-        hasAnimated: false
-      })
+      this.setState({ hasAnimated: false })
     }
   }
 
   render() {
-    const { initiallyVisible, children, classes } = this.props
+    const {
+      children,
+      classes,
+      initiallyVisible,
+    } = this.props
+
     const { hasAnimated } = this.state
+
     const propStyles = this.props.style
-    const opacity = (propStyles.animationDelay !== undefined && !initiallyVisible) ? 0 : propStyles.opacity
-    const style = Object.assign({}, propStyles, { opacity: hasAnimated ? 1 : opacity })
+    const opacity = propStyles.animationDelay !== undefined && !initiallyVisible
+      ? 0
+      : propStyles.opacity
+
+    const style = Object.assign(
+      {},
+      propStyles,
+      { opacity: hasAnimated ? 1 : opacity }
+    )
 
     return (
       <div className={classes} style={style} ref={ref => this.ref = ref}>
@@ -361,5 +393,5 @@ class AnimatedElement extends Component {
 
 AnimatedElement.propTypes = {
   classes: PropTypes.string,
-  style: PropTypes.object
+  style: PropTypes.object,
 }


### PR DESCRIPTION
While working on [this epic][epic], found that some modification where needed to this library to allow the ability to keep the underlying structure. In the course of those modifications, I found myself making minor style corrections here and there. As these piled up, I noticed the diff was getting further and further from properly representing the change set and looks more like a styling "refactor".

Decided to just break all those changes out into a separate PR and address the remaining bits. I started to go as far as getting a linter in there and updating the deps, but that turned out to be a MAJOR 🐇 🕳️ . So just going baby steps with this and starting with the styles.

Will publish these changes with the modifications we will be making on the `a11y` work. As such there are no need for regression testing on this change. It will be covered on the `a11y` work to be followed up by this.

[epic]: https://github.com/articulate/rise-frontend/issues/2401