### PR TITLE
Maintain underlying DOM structure when desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,25 @@ function(visible) {
 }
 ```
 
+**keepStructure**
+
+This is a `Boolean` value that will not add additional structure to its children
+to facilitate animation when set to `true`. This comes in handy when keeping the
+structure required for proper semantic html.
+
+In order to properly animate while keeping the structure, a few requirements must
+be met:
+
+1. Elements to be animated must be wrapped in a single "root" element.
+1. When either the "root" OR any of the elements to be animated are React components, a ref to element to be animated must be provided on the component as `animateRef`.
+1. When either the "root" OR any of the elements to be animated are plain ol' DOM elements, no additional ref exposure is required.
+
+When `keepStructure` is set to `true`, the component will check if it only has
+one child, if it does it will not create the wrapping `div` and will instead
+use the root element as the container. If there is more than one child, then
+it will default to creating and inserting a  `div` that will wrap the provided
+children.
+
 ## Changes:
 ### Version 2.1.0
 * Can now use scrollableParentSelector to use ScrollAnimation within any scrolling parent element.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/react-animate-on-scroll",
-  "version": "2.2.5",
+  "version": "2.3.0",
   "description": "React component to animate elements on scroll with animate.css",
   "main": "dist/scrollAnimation.min.js",
   "scripts": {


### PR DESCRIPTION
This PR is in response to the List portion of [this epic][epic]

One of the real bummers with this library is the changes that it makes to the underlying DOM structure in which it wraps. A `div` is added, wrapping the `children` as a way to determine the scroll position. In addition to that `div`, each child to be animated is wrapped in an additional `div` to control the animation. 

While this is really handy in most situations, it breaks down semantic HTML in some places. For instance, the case that sparked this change was around our `List`  block in `360`. We want to animate in the list items which causes us to end up wrapping:

<details><summary>Show examples</summary>

```jsx
<ul>
  <Animate>
    <li>item 1</li>
    <li>item 2</li>
  </Animate>
</ul>
```
Which ends up rendering like:

```html
<ul>
  <div>
    <div><li>item 1</li></div>
    <div><li>item 2</li></div>
  </div>
</ul>
```
</details>

This tends to be problematic for `a11y` as it blows away well intended, semantic structure. Also it makes it difficult to employ roles and other techniques that can be used when semantic structure is not 

As a way to solve this issue, this PR adds a new prop `keepStructure` that will keep the structure of the children intact. When the prop is marked `true` and only a single component is present in the children, then the single component will become the container used to determine scroll position and any children of that component will handle their animation. So now it looks like:

<details><summary>Show examples</summary>

```jsx
<ul>
  <Animate keepStructure={true}>
    <li>item 1</li>
    <li>item 2</li>
  </Animate>
</ul>
```
Which ends up rendering like:

```html
<ul>
  <li>item 1</li>
  <li>item 2</li>
</ul>
```
</details>

Which now keeps the desired structure.

In order to test these changes, there is a [frontend-pr][frontend] that implements them.

## Links
* [frontend-pr][frontend]
* [epic][epic]

## Testing
The testing of this is covered in the [frontend-pr][frontend]

[frontend]: https://github.com/articulate/rise-frontend/pull/2444
[epic]: https://github.com/articulate/rise-frontend/issues/2401